### PR TITLE
Fixed Proxy URI parsing with login:password contained @

### DIFF
--- a/MultiFactor.Radius.Adapter/Core/ProxyFactory/WebProxyException.cs
+++ b/MultiFactor.Radius.Adapter/Core/ProxyFactory/WebProxyException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace MultiFactor.Radius.Adapter.Core
+{
+    [Serializable]
+    internal class WebProxyException : Exception
+    {
+        public WebProxyException() { }
+        public WebProxyException(string message) : base(message) { }
+        public WebProxyException(string message, Exception inner) : base(message, inner) { }
+        protected WebProxyException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/MultiFactor.Radius.Adapter/Core/ProxyFactory/WebProxyFactory.cs
+++ b/MultiFactor.Radius.Adapter/Core/ProxyFactory/WebProxyFactory.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Web;
+
+namespace MultiFactor.Radius.Adapter.Core
+{
+    public static class WebProxyFactory
+    {
+        
+
+        public static bool TryCreateWebProxy(string apiUri, out WebProxy proxy)
+        {
+            if (!TryParseUri(apiUri, out var proxyUri))
+            {
+                proxy = null;
+                return false;
+            }
+            
+            proxy = new WebProxy(proxyUri);
+            SetProxyCredentials(proxy, proxyUri);
+            return true;
+        }
+
+        private static bool TryParseUri(string apiUri, out Uri uri)
+        {
+            if(Uri.TryCreate(apiUri, UriKind.Absolute,  out uri))
+            {
+                return true;
+            }
+            var uriSeparatorIdx = apiUri.LastIndexOf('@');
+            if (uriSeparatorIdx == -1)
+            {
+                return false;
+            }
+
+            var leftPart = apiUri.Substring(0, uriSeparatorIdx).Replace("@", "%40");
+            var rightPart = apiUri.Substring(uriSeparatorIdx + 1);
+            var escapedUri = $"{leftPart}@{rightPart}";
+            uri = new Uri(escapedUri);
+            return true;
+        }
+
+        private static void SetProxyCredentials(WebProxy proxy, Uri proxyUri)
+        {
+            if (string.IsNullOrEmpty(proxyUri.UserInfo))
+            {
+                return;
+            }
+
+            var credentials = proxyUri.UserInfo.Split(new[] {':'}, 2);
+            proxy.Credentials = new NetworkCredential(credentials[0], credentials[1]);
+        }
+    }
+}

--- a/MultiFactor.Radius.Adapter/MultiFactor.Radius.Adapter.csproj
+++ b/MultiFactor.Radius.Adapter/MultiFactor.Radius.Adapter.csproj
@@ -125,6 +125,7 @@
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
@@ -149,6 +150,8 @@
     <Compile Include="Configuration\ValueElement.cs" />
     <Compile Include="Configuration\ValueElementCollection.cs" />
     <Compile Include="Core\Constants.cs" />
+    <Compile Include="Core\ProxyFactory\WebProxyException.cs" />
+    <Compile Include="Core\ProxyFactory\WebProxyFactory.cs" />
     <Compile Include="Extensions\LoggingConfiguration.cs" />
     <Compile Include="Extensions\LogLevelConfiguration.cs" />
     <Compile Include="Extensions\ServicesConfiguration.cs" />
@@ -268,6 +271,5 @@
       <DependentUpon>ServiceInstaller.cs</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/MultiFactor.Radius.Adapter/Services/MultiFactorApi/MultiFactorApiClient.cs
+++ b/MultiFactor.Radius.Adapter/Services/MultiFactorApi/MultiFactorApiClient.cs
@@ -183,15 +183,14 @@ namespace MultiFactor.Radius.Adapter.Services.MultiFactorApi
 
                     if (!string.IsNullOrEmpty(_serviceConfiguration.ApiProxy))
                     {
-                        _logger.Debug("Using proxy " + _serviceConfiguration.ApiProxy);
-                        var proxyUri = new Uri(_serviceConfiguration.ApiProxy);
-                        web.Proxy = new WebProxy(proxyUri);
-
-                        if (!string.IsNullOrEmpty(proxyUri.UserInfo))
+                        _logger.Debug("Using proxy " + _serviceConfiguration.ApiProxy); 
+                        if (!WebProxyFactory.TryCreateWebProxy(_serviceConfiguration.ApiProxy, out var webProxy))
                         {
-                            var credentials = proxyUri.UserInfo.Split(new[] { ':' }, 2);
-                            web.Proxy.Credentials = new NetworkCredential(credentials[0], credentials[1]);
+                            _logger.Error("Unable to initialize WebProxy {0}", 
+                                _serviceConfiguration.ApiProxy);
+                            throw new WebProxyException(_serviceConfiguration.ApiProxy);
                         }
+                        web.Proxy = webProxy;
                     }
 
                     responseData = await web.UploadDataTaskAsync(url, "POST", requestData);


### PR DESCRIPTION
- Proper handling for a URI specific cases, when user info contains an @ special character. Now user:info part @ replaced with %40 escape sequence