### PR TITLE
DEV-927

### DIFF
--- a/MultiFactor.Radius.Adapter/Services/MultiFactorApi/MultiFactorApiClient.cs
+++ b/MultiFactor.Radius.Adapter/Services/MultiFactorApi/MultiFactorApiClient.cs
@@ -116,9 +116,11 @@ namespace MultiFactor.Radius.Adapter.Services.MultiFactorApi
 
                 return response.Model;
             }
-            catch (TaskCanceledException tce)
+            catch (TaskCanceledException)
             {
-                throw new MultifactorApiUnreachableException($"Multifactor API host unreachable: {url}. Reason: Http request timeout", tce);
+                var message = "Multifactor API timeout expired.";
+                _logger.Warning(message);
+                return new AccessRequestDto() { Status = Literals.RadiusCode.Denied, ReplyMessage = message };
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Release 24.09.2025 | AccessReject when API timeout
#### Fixed
-   If the `multifactor-api-timeout` expires, the warning `Multifactor API timeout expired` will be written and `AccessReject` will be returned.